### PR TITLE
avoid npm-run-all

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "clean": "rimraf lib",
     "build": "webpack",
-    "prepare": "npx npm-run-all clean build"
+    "prepare": "webpack"
   },
   "activationEvents": [
     "*"


### PR DESCRIPTION
For me `yarn install --frozen-lockfile` fail. 

I got the same issue with coc-java, where I opened an issue and the maintainer fixed it with this change. 

the same problem on coc-java : https://github.com/neoclide/coc-java/issues/154

on my machine replacing `npx npm-run-all clean build` with webpack fixed it.

have a good day / night !